### PR TITLE
Commenting out some classes that have references to missing assets

### DIFF
--- a/assets/css/argon.css
+++ b/assets/css/argon.css
@@ -26453,7 +26453,7 @@ table.dataTable tbody > tr.selected
     }
 }
 
-[data-calendar-month='0']
+/* [data-calendar-month='0']
 {
     background-image: url('../img/calendar/january.jpg');
 }
@@ -26511,7 +26511,7 @@ table.dataTable tbody > tr.selected
 [data-calendar-month='11']
 {
     background-image: url('../img/calendar/december.jpg');
-}
+} */
 
 .card-calendar .card-header
 {


### PR DESCRIPTION
There are some assets that are missing so the library cannot be compiled via webpack. I am commenting these lines out. We can either merge this or have those assets available in a new version. This is blocking me right now. I hope it can get fixed as soon as possible. Thanks!